### PR TITLE
Feature/proc macro

### DIFF
--- a/coi-derive/Cargo.toml
+++ b/coi-derive/Cargo.toml
@@ -13,6 +13,6 @@ categories = ["dependency", "injection", "control"]
 proc-macro = true
 
 [dependencies]
-syn = "1.0.11"
+syn = { version = "1.0.11", features = ["full"] }
 quote = "1.0.2"
 proc-macro2 = "1.0.6"

--- a/coi-derive/src/lib.rs
+++ b/coi-derive/src/lib.rs
@@ -1,13 +1,148 @@
 extern crate proc_macro;
 use proc_macro::TokenStream;
-use proc_macro2::TokenStream as TokenStream2;
-use syn::{parse_macro_input, DeriveInput};
+use proc_macro2::{Ident, TokenTree};
+use quote::{format_ident, quote};
+use syn::{
+    parse::{Parse, ParseStream},
+    parse_macro_input, Data, DeriveInput, Error, Fields, FnArg, Path, Result, Type,
+};
+
+struct Provides {
+    interface: Path,
+    with: Path,
+}
+
+impl Parse for Provides {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let interface = input.parse()?;
+        input.parse().and_then(|ident: Ident| {
+            if ident.eq("with") {
+                Ok(())
+            } else {
+                Err(Error::new(ident.span(), "expected `with`"))
+            }
+        })?;
+        let with = input.parse()?;
+        Ok(Provides { interface, with })
+    }
+}
+
+#[proc_macro_derive(Inject, attributes(provides, inject))]
+pub fn inject_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let data_struct = match input.data {
+        Data::Struct(data_struct) => data_struct,
+        _ => {
+            return Error::new_spanned(input, "#[derive(Inject)] only supports structs")
+                .to_compile_error()
+                .into()
+        }
+    };
+    let provider = format_ident!("{}Provider", input.ident);
+    let attr = match input
+        .attrs
+        .into_iter()
+        .filter(|attr| {
+            attr.path
+                .segments
+                .first()
+                .map(|p| p.ident.eq("provides"))
+                .unwrap_or(false)
+        })
+        .next()
+    {
+        None => {
+            return Error::new_spanned(
+                input.ident,
+                "#[derive(Inject)] requires a `provides` attribute",
+            )
+            .to_compile_error()
+            .into()
+        }
+        Some(attr) => attr,
+    };
+
+    let (arg_ident, arg_type): (Vec<Ident>, Vec<Type>) = match data_struct.fields {
+        Fields::Named(named_fields) => named_fields
+            .named
+            .into_iter()
+            .map(|field| (field.ident.unwrap(), field.ty))
+            .unzip(),
+        // FIXME(pfaria) add support for unnamed fields by allowing the name to be
+        // specified as part of the attribute params
+        Fields::Unnamed(_) => {
+            return Error::new_spanned(data_struct.fields, "unnamed fields cannot be injected")
+                .to_compile_error()
+                .into()
+        }
+        Fields::Unit => (vec![], vec![]),
+    };
+
+    let attr2 = attr.clone();
+    let mut token_iter = attr2.tokens.into_iter();
+    let provides = match token_iter.next() {
+        Some(TokenTree::Group(group)) => {
+            let token_stream = TokenStream::from(group.stream());
+            parse_macro_input!(token_stream as Provides)
+        }
+        _ => panic!(),
+    };
+    let interface = provides.interface;
+    let provides_with = provides.with;
+
+    if let Some(s) = token_iter.next() {
+        return Error::new_spanned(
+            s,
+            "Only expected the format #[provides `Interface` with `provider`]",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    let arg_key: Vec<String> = arg_ident.iter().map(|i| i.to_string()).collect();
+    let container = format_ident!(
+        "{}",
+        if arg_ident.len() == 0 {
+            "_"
+        } else {
+            "container"
+        }
+    );
+    let input_ident = input.ident;
+    let expanded = quote! {
+        impl Injectable for #input_ident {}
+
+        struct #provider;
+
+        #[async_trait::async_trait]
+        impl ::coi::Provide for #provider {
+            type Output = ::std::sync::Arc<dyn #interface + Send + Sync + 'static>;
+
+            async fn provide(&self, #container: &::coi::Container) -> ::coi::Result<Self::Output> {
+                #( let #arg_ident = #container.resolve::<#arg_type>(#arg_key).await?; )*
+                Ok(::std::sync::Arc::new(#provides_with(#(#arg_ident),*))
+                    as ::std::sync::Arc<dyn #interface + Send + Sync + 'static>)
+            }
+        }
+    };
+    TokenStream::from(expanded)
+}
 
 #[proc_macro_attribute]
-pub fn inject(metadata: TokenStream, input: TokenStream) -> TokenStream {
-    let input = TokenStream2::from(input);
-    let output: TokenStream2 = {
-        unimplemented!()
+pub fn inject(_metadata: TokenStream, input: TokenStream) -> TokenStream {
+    let fn_arg = parse_macro_input!(input as FnArg);
+    let arg = match fn_arg {
+        FnArg::Receiver(receiver) => return Error::new_spanned(receiver, "cannot inject `self` args")
+            .to_compile_error()
+            .into(),
+        FnArg::Typed(arg) => arg
     };
-    TokenStream::from(output)
+    let attrs = arg.attrs;
+    let pat = arg.pat;
+    let ty = arg.ty;
+
+    let expanded = quote! {
+        #(#attrs)* #pat : ::std::sync::Arc<#ty + Send + Sync + 'static>
+    };
+    TokenStream::from(expanded)
 }

--- a/coi-test/Cargo.toml
+++ b/coi-test/Cargo.toml
@@ -8,5 +8,6 @@ repository = "https://github.com/Nashenas88/coi"
 readme = "../README.md"
 
 [dependencies]
+async-std = { version = "1.4.0", features = ["attributes"] }
 async-trait = "0.1.22"
 coi = { path = "../coi" }

--- a/coi-test/src/main.rs
+++ b/coi-test/src/main.rs
@@ -1,11 +1,11 @@
-use coi::{ContainerBuilder, Inject, Injectable, inject};
+use coi::{ContainerBuilder, Injectable};
 use std::sync::Arc;
 
 trait Interface1 : Injectable {
     fn describe(&self) -> &'static str;
 }
 
-#[derive(Inject)]
+#[derive(Injectable)]
 #[provides(Interface1 with Impl1::new)]
 struct Impl1;
 
@@ -25,7 +25,7 @@ trait Interface2 : Injectable {
     fn deep_describe(&self) -> String;
 }
 
-#[derive(Inject)]
+#[derive(Injectable)]
 #[provides(Interface2 with Impl2::new)]
 struct Impl2 {
     #[inject]

--- a/coi-test/src/main.rs
+++ b/coi-test/src/main.rs
@@ -1,3 +1,57 @@
-fn main() {
-    
+use coi::{ContainerBuilder, Inject, Injectable, inject};
+use std::sync::Arc;
+
+trait Interface1 : Injectable {
+    fn describe(&self) -> &'static str;
+}
+
+#[derive(Inject)]
+#[provides(Interface1 with Impl1::new)]
+struct Impl1;
+
+impl Impl1 {
+    fn new() -> Self {
+        Impl1
+    }
+}
+
+impl Interface1 for Impl1 {
+    fn describe(&self) -> &'static str {
+        "I'm impl1!"
+    }
+}
+
+trait Interface2 : Injectable {
+    fn deep_describe(&self) -> String;
+}
+
+#[derive(Inject)]
+#[provides(Interface2 with Impl2::new)]
+struct Impl2 {
+    #[inject]
+    interface1: Arc<dyn Interface1>,
+}
+
+impl Impl2 {
+    fn new(interface1: Arc<dyn Interface1>) -> Self {
+        Self {
+            interface1,
+        }
+    }
+}
+
+impl Interface2 for Impl2 {
+    fn deep_describe(&self) -> String  {
+        format!("I'm impl2! and I have {}", self.interface1.describe())
+    }
+}
+
+#[async_std::main]
+async fn main() {
+    let container = ContainerBuilder::new()
+        .register("interface1", Impl1Provider)
+        .register("interface2", Impl2Provider)
+        .build();
+    let interface2 = container.resolve::<Arc<dyn Interface2>>("interface2").await.expect("Should exist");
+    println!("Deep description: {}", interface2.deep_describe());
 }

--- a/coi/src/lib.rs
+++ b/coi/src/lib.rs
@@ -101,7 +101,7 @@ impl ContainerBuilder {
 #[async_trait]
 pub trait Provide {
     /// The type that this provider is intended to produce
-    type Output: Send + Sync + 'static;
+    type Output: Injectable;
 
     /// Only intended to be used internally
     async fn provide(&self, container: &Container) -> Result<Self::Output>;

--- a/coi/src/lib.rs
+++ b/coi/src/lib.rs
@@ -3,6 +3,7 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::fmt::{self, Display};
 use std::sync::Arc;
+pub use coi_derive::*;
 
 #[derive(Debug)]
 pub enum Error {
@@ -36,6 +37,10 @@ impl std::error::Error for Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+pub trait Injectable: Send + Sync + 'static {}
+
+impl<T: Injectable + ?Sized> Injectable for Arc<T> {}
+
 #[derive(Clone)]
 pub struct Container {
     provider_map: HashMap<String, Arc<dyn Any + Send + Sync + 'static>>,
@@ -45,14 +50,14 @@ impl Container {
     /// Construct or lookup a previously constructed object of type `T` with key `key`.
     pub async fn resolve<T>(&self, key: &str) -> Result<T>
     where
-        T: Send + Sync + 'static,
+        T: Injectable,
     {
         let any_provider = self
             .provider_map
             .get(key)
             .ok_or_else(|| Error::KeyNotFound(key.to_owned()))?;
         let provider = any_provider
-            .downcast_ref::<Arc<dyn Provider<Output = T> + Send + Sync + 'static>>()
+            .downcast_ref::<Arc<dyn Provide<Output = T> + Send + Sync + 'static>>()
             .ok_or_else(|| Error::TypeMismatch(key.to_owned()))?;
         // FIXME(pfaria) memoize results when singleton registration is introduced
         provider.provide(self).await
@@ -76,11 +81,11 @@ impl ContainerBuilder {
     pub fn register<K, P, T>(mut self, key: K, provider: P) -> Self
     where
         K: Into<String>,
-        T: Send + Sync + 'static,
-        P: Provider<Output = T> + Send + Sync + 'static,
+        T: Injectable,
+        P: Provide<Output = T> + Send + Sync + 'static,
     {
         let key = key.into();
-        let provider = Arc::new(provider) as Arc<dyn Provider<Output = T> + Send + Sync + 'static>;
+        let provider = Arc::new(provider) as Arc<dyn Provide<Output = T> + Send + Sync + 'static>;
         self.provider_map.insert(key, Arc::new(provider));
         self
     }
@@ -94,7 +99,7 @@ impl ContainerBuilder {
 }
 
 #[async_trait]
-pub trait Provider {
+pub trait Provide {
     /// The type that this provider is intended to produce
     type Output: Send + Sync + 'static;
 


### PR DESCRIPTION
**What**
Adding proc macros to implement `Injectable` trait and `Provide` traits, structs and impls.

**Why**
The goal of this library is to provide a simple to use dependency-injection library. Providing proc-macro attributes that allow the user to get more done while typing less is heading in that direction.

**How**
impl the marker trait `Injectable` for the marked struct. Also create a `[struct name]Provider` struct that impls `Provide` for the the supplied interface. The generated `Provide` impl also resolves all dependencies with the supplied `container`, which will recursively resolve the dependency tree.