### PR TITLE
coi: Ensure transient registrations are also copied when scoping containers

### DIFF
--- a/coi/src/lib.rs
+++ b/coi/src/lib.rs
@@ -543,7 +543,7 @@ impl Container {
                 .provider_map
                 .iter()
                 .filter_map(|(k, v)| match v.kind {
-                    kind @ RegistrationKind::Scoped => Some((
+                    kind @ RegistrationKind::Scoped | kind @ RegistrationKind::Transient => Some((
                         k.clone(),
                         Registration {
                             kind,


### PR DESCRIPTION
Fixes #8 