### PR TITLE
Add github bug, feature and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -1,0 +1,37 @@
+<!---
+    Please fill out this template to help the devs who will be
+    investigating this bug.
+--->
+
+**What**
+<!---
+    Add a brief summary of the bug.
+--->
+
+**Steps to Reproduce**
+<!---
+    Add a step-by-step list of instructions of how to reproduce this
+    issue. The less ambiguous the better
+--->
+
+**Expected Behavior**
+<!---
+    Explain what you believe the outcome should be when the above steps
+    are run.
+--->
+
+**Actual Behavior**
+<!---
+    Explain what you actually see when the above steps are run.
+--->
+
+**Minimized Code Sample**
+<!---
+    If possible, please provide a minimized chunk of code that reproduces
+    the issue. If it's too long to past here, please add a link to where
+    the code can be viewed if possible.
+--->
+
+OS Version: <!--- on *nix systems, something like `uname -a` --->
+Rust Version: <!--- output of `rustc--version` --->
+Coi Version: <!--- version of the coi crate where this was seen --->

--- a/.github/ISSUE_TEMPLATE/bug_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_template.md
@@ -3,35 +3,36 @@
     investigating this bug.
 --->
 
-**What**
+## What
 <!---
     Add a brief summary of the bug.
 --->
 
-**Steps to Reproduce**
+## Steps to Reproduce
 <!---
     Add a step-by-step list of instructions of how to reproduce this
     issue. The less ambiguous the better
 --->
 
-**Expected Behavior**
+## Expected Behavior
 <!---
     Explain what you believe the outcome should be when the above steps
     are run.
 --->
 
-**Actual Behavior**
+## Actual Behavior
 <!---
     Explain what you actually see when the above steps are run.
 --->
 
-**Minimized Code Sample**
+## Minimized Code Sample
 <!---
     If possible, please provide a minimized chunk of code that reproduces
     the issue. If it's too long to past here, please add a link to where
     the code can be viewed if possible.
 --->
 
+## Versions
 OS Version: <!--- on *nix systems, something like `uname -a` --->
 Rust Version: <!--- output of `rustc--version` --->
 Coi Version: <!--- version of the coi crate where this was seen --->

--- a/.github/ISSUE_TEMPLATE/feature_request_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.md
@@ -1,0 +1,23 @@
+<!---
+    Hopefully, this doesn't come across as too intimidating, but it would
+    be really appreciated if you could fill out this template when
+    requesting a new feature. Thank you!
+--->
+
+**What**
+<!---
+    Should be a summary of the change
+--->
+
+**Why**
+<!---
+    Why do you think this will be an improvement to the crate?
+--->
+
+**Examples**
+<!---
+    Could you provide any examples of what the new api would look like
+    in practice?
+--->
+
+- [ ] Would this be a breaking change?

--- a/.github/ISSUE_TEMPLATE/feature_request_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.md
@@ -4,20 +4,21 @@
     requesting a new feature. Thank you!
 --->
 
-**What**
+## What
 <!---
     Should be a summary of the change
 --->
 
-**Why**
+## Why
 <!---
     Why do you think this will be an improvement to the crate?
 --->
 
-**Examples**
+## Examples
 <!---
     Could you provide any examples of what the new api would look like
     in practice?
 --->
 
+## Checklist
 - [ ] Would this be a breaking change?

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -6,20 +6,21 @@
     could be filled out.
 --->
 
-**What**
+## What
 <!---
     Add a brief summary of your change.
 --->
 
-**Why**
+## Why
 <!---
     Add a detailed explanation of why this change would be needed
 --->
 
-**How**
+## How
 <!---
     Explain how your change is implemented and how it achieves
     the "Why" above
 --->
 
+## Checks
 - [ ] Did you run `make fmt` as a final commit?

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,25 @@
+<!---
+    This template is only a suggestion to help improve PR quality in this
+    repo. If you don't feel it makes sense for your PR, or if you're
+    really in a rush and it's a small change, feel free to skip it. If
+    it's a more involved change, it would really be appreciated if this
+    could be filled out.
+--->
+
+**What**
+<!---
+    Add a brief summary of your change.
+--->
+
+**Why**
+<!---
+    Add a detailed explanation of why this change would be needed
+--->
+
+**How**
+<!---
+    Explain how your change is implemented and how it achieves
+    the "Why" above
+--->
+
+- [ ] Did you run `make fmt` as a final commit?


### PR DESCRIPTION
<!---
    This template is only a suggestion to help improve PR quality in this
    repo. If you don't feel it makes sense for your PR, or if you're
    really in a rush and it's a small change, feel free to skip it. If
    it's a more involved change, it would really be appreciated if this
    could be filled out.
--->

## What
This adds github templates for bugs, feature requests and pull requests.

## Why
I've been getting sloppy with PR's and would like to keep track of changes better, especially for reviewing purposes. I feel it makes the decisions more sound if they have to be explained more explicitly.

## How
Added a `.github` hidden dir with subdirectories for the various templates.

## Checks
- [x] Did you run `make fmt` as a final commit?
**N/A**
