### PR TITLE
Fix incorrectly generated debug fn, update tests

### DIFF
--- a/coi-derive/src/lib.rs
+++ b/coi-derive/src/lib.rs
@@ -394,8 +394,8 @@ pub fn provide_derive(input: TokenStream) -> TokenStream {
             quote! {
                 fn dependencies(
                     &self
-                ) -> Vec<&'static str> {
-                    vec![]
+                ) -> &'static [&'static str] {
+                    &[]
                 }
             }
         }]

--- a/coi-test-debug/tests/debug.rs
+++ b/coi-test-debug/tests/debug.rs
@@ -60,12 +60,15 @@ impl Impl5 {
 impl Trait5 for Impl5 {}
 
 #[derive(Inject)]
-pub struct StructA<T>(T) where T: Clone;
+pub struct StructA<T>(T)
+where
+    T: Clone;
 
 #[derive(Provide)]
 #[coi(provides StructA<T> with StructA(self.0.clone()))]
-pub struct StructAProvider<T>(T) where T: Clone;
-
+pub struct StructAProvider<T>(T)
+where
+    T: Clone;
 
 #[test]
 fn main() {

--- a/coi-test-debug/tests/debug.rs
+++ b/coi-test-debug/tests/debug.rs
@@ -1,4 +1,4 @@
-use coi::{container, Inject};
+use coi::{container, Inject, Provide};
 use std::sync::Arc;
 
 trait Trait1: Inject {}
@@ -59,14 +59,24 @@ impl Impl5 {
 
 impl Trait5 for Impl5 {}
 
+#[derive(Inject)]
+pub struct StructA<T>(T) where T: Clone;
+
+#[derive(Provide)]
+#[coi(provides StructA<T> with StructA(self.0.clone()))]
+pub struct StructAProvider<T>(T) where T: Clone;
+
+
 #[test]
 fn main() {
+    let struct_a_provider = StructAProvider(String::from("a"));
     let container = container! {
         trait1 => Impl1Provider,
         trait2 => Impl2Provider; scoped,
         trait3 => Impl3Provider,
         trait4 => Impl4Provider; singleton,
         trait5 => Impl5Provider,
+        structa => struct_a_provider; singleton,
     };
     let debugged = format!("{:?}", container);
     assert!(debugged.contains(r#""trait1": []"#));
@@ -74,4 +84,5 @@ fn main() {
     assert!(debugged.contains(r#""trait3": []"#));
     assert!(debugged.contains(r#""trait4": []"#));
     assert!(debugged.contains(r#""trait5": ["trait1", "trait2", "trait3", "trait4"]"#));
+    assert!(debugged.contains(r#""structa": []"#));
 }


### PR DESCRIPTION
<!---
    This template is only a suggestion to help improve PR quality in this
    repo. If you don't feel it makes sense for your PR, or if you're
    really in a rush and it's a small change, feel free to skip it. If
    it's a more involved change, it would really be appreciated if this
    could be filled out.
--->

## What
<!---
    Add a brief summary of your change.
--->
Addresses https://github.com/Nashenas88/coi-actix-sample/issues/2
Generate `fn dependencies(&self) -> &'static[&'static str]` instead of one that returns `Vec<&'static str>`.

## Why
<!---
    Add a detailed explanation of why this change would be needed
--->
There were no tests for the dependencies fn generated for the Provide derive in debug mode. That derive was generated an old format for the dependencies fn.

## Checks
- [x] Did you run `make fmt` as a final commit?
